### PR TITLE
Update Github action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
      
       # Use Nerdbank.GitVersioning to set version variables: https://github.com/AArnott/nbgv
       - name: Use Nerdbank.GitVersioning to set version variables
-        uses: aarnott/nbgv@v0.3
+        uses: aarnott/nbgv@v0.3 # change to dotnet/nbgv
         with:
           setAllVars: true
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
      
       # Use Nerdbank.GitVersioning to set version variables: https://github.com/AArnott/nbgv
       - name: Use Nerdbank.GitVersioning to set version variables
-        uses: aarnott/nbgv@v0.3 # change to dotnet/nbgv
+        uses: dotnet/nbgv@v0.3
         with:
           setAllVars: true
 


### PR DESCRIPTION
The `aarnott/nbgv` repo behind the Github Action you're using has recently moved to `dotnet/nbgv` as part of its move to the .NET Foundation.